### PR TITLE
Fix geometry check in get_routes to handle None values

### DIFF
--- a/gtfs_kit/routes.py
+++ b/gtfs_kit/routes.py
@@ -126,7 +126,7 @@ def get_routes(
             lines = [
                 g
                 for g in group["geometry"]
-                if g.geom_type in ["LineString", "MultiLineString"]
+                if g and g.geom_type in ["LineString", "MultiLineString"]
             ]
             if not lines:
                 return pd.Series({"geometry": None})


### PR DESCRIPTION
While using gtfs_kit to display routes on a map, I encountered the following error:

```
AttributeError: 'NoneType' object has no attribute 'geom_type'
Traceback:

File "/Users/me/workspace/company/project/src/streamlit_app.py", line 85, in <module>
    pg.run()
    ~~~~~~^^
File "/Users/me/workspace/company/project/.venv/lib/python3.13/site-packages/streamlit/navigation/page.py", line 300, in run
    exec(code, module.__dict__)  # noqa: S102
    ~~~~^^^^^^^^^^^^^^^^^^^^^^^
File "/Users/me/workspace/company/project/src/ui/pages/network/inspect.py", line 27, in <module>
    routes_map = gk.map_routes(gtfs_feed, route_ids=gtfs_feed.routes.route_id.tolist())
File "/Users/me/workspace/company/project/.venv/lib/python3.13/site-packages/gtfs_kit/routes.py", line 846, in map_routes
    collection = feed.routes_to_geojson(
        route_ids=[route_id], include_stops=show_stops
    )
File "/Users/me/workspace/company/project/.venv/lib/python3.13/site-packages/gtfs_kit/routes.py", line 788, in routes_to_geojson
    g = get_routes(feed, as_gdf=True, split_directions=split_directions).loc[
        ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/Users/me/workspace/company/project/.venv/lib/python3.13/site-packages/gtfs_kit/routes.py", line 750, in get_routes
    .apply(merge_lines, include_groups=False)
     ~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/Users/me/workspace/company/project/.venv/lib/python3.13/site-packages/pandas/core/groupby/groupby.py", line 1820, in apply
    return self._python_apply_general(f, self._obj_with_exclusions)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/Users/me/workspace/company/project/.venv/lib/python3.13/site-packages/pandas/core/groupby/groupby.py", line 1886, in _python_apply_general
    values, mutated = self._grouper.apply_groupwise(f, data, self.axis)
                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^
File "/Users/me/workspace/company/project/.venv/lib/python3.13/site-packages/pandas/core/groupby/ops.py", line 919, in apply_groupwise
    res = f(group)
File "/Users/me/workspace/company/project/.venv/lib/python3.13/site-packages/gtfs_kit/routes.py", line 738, in merge_lines
    if g.geom_type in ["LineString", "MultiLineString"]
```
    
This quick fix adds a check to handle NoneType geometries, which resolves the crash.